### PR TITLE
Adds options for passing scope to omniauth flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ You use OmniAuth::Blockstack like you do any other OmniAuth strategy:
 use OmniAuth::Blockstack
 ```
 
+If you want to pass [scopes](https://github.com/blockstack/blockstack.js/tree/master/src/auth#scopes) to the authentication flow:
+
+```ruby
+use OmniAuth::Blockstack, scope: ['publish_data', 'store_write', 'email']
+```
+
 ### Authentication Process
 
 When you authenticate through `omniauth-blockstack` you can send users to `/auth/blockstack` and it will redirect

--- a/lib/omniauth/strategies/auth-request.js
+++ b/lib/omniauth/strategies/auth-request.js
@@ -1,3 +1,3 @@
 document.addEventListener("DOMContentLoaded", function(event) {
-  blockstack.redirectToSignIn(redirectURI, manifestURI)
+  blockstack.redirectToSignIn(redirectURI, manifestURI, scopes)
 })

--- a/lib/omniauth/strategies/blockstack.rb
+++ b/lib/omniauth/strategies/blockstack.rb
@@ -47,17 +47,19 @@ module OmniAuth
         auth_request_js = File.open(File.join(File.dirname(__FILE__), "auth-request.js"), "rb").read
 
         header_info = "<script>#{blockstack_js}</script>"
-        app_data_js = <<~JAVASCRIPT
+        app_data_js = <<~EOS
         var manifestURI = "#{callback_url.chomp("/callback") + "?manifest=true"}"
         var redirectURI = "#{callback_url}"
-
-        JAVASCRIPT
+        var scopes = #{options.scope ? '['+options.scope.map {|s| "'#{s}'"}.join(',') + ']' : null}
+        EOS
 
         header_info << "<script>#{app_data_js}</script>"
         header_info << "<script>#{auth_request_js}</script>"
-        form = OmniAuth::Form.new(:title => "Blockstack Auth Request Generator",
-        :header_info => header_info,
-        :url => callback_path)
+        form = OmniAuth::Form.new(
+          :title => "Blockstack Auth Request Generator",
+          :header_info => header_info,
+          :url => callback_path
+        )
         form.to_response
       end
 


### PR DESCRIPTION
This small PR adds the ability to pass scopes to the authentication flow with Omniauth.

Notes:

- I used the `scope` option for omniauth configuration instead of `scopes` to better match the normal method of passing a `scope` parameter to omniauth (with Oauth). I could certainly be convinced that `scopes` is better to match the JS terminology. Or perhaps even better would be to support both `scopes` and `scope`.