### PR TITLE
Get rid of the connect button

### DIFF
--- a/lib/omniauth/blockstack/version.rb
+++ b/lib/omniauth/blockstack/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
   module Blockstack
-    VERSION = "19.1.0"
+    VERSION = "19.1.1"
   end
 end

--- a/lib/omniauth/strategies/blockstack.rb
+++ b/lib/omniauth/strategies/blockstack.rb
@@ -55,10 +55,20 @@ module OmniAuth
 
         header_info << "<script>#{app_data_js}</script>"
         header_info << "<script>#{auth_request_js}</script>"
-        form = OmniAuth::Form.new(:title => "Blockstack Auth Request Generator",
-        :header_info => header_info,
-        :url => callback_path)
-        form.to_response
+
+        title = "Redirecting to Blockstack"
+        html << <<-HTML
+          <!DOCTYPE html>
+          <html>
+          <head>
+            <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+            <title>#{title}</title>
+            #{header_info}
+          </head>
+          <body>Redirecting to blockstack</body>
+          </html>
+        HTML
+        Rack::Response.new(html, 200, 'content-type' => 'text/html').finish
       end
 
       def callback_phase


### PR DESCRIPTION
Removing the connect button, since the redirection is handled by Blockstack.js with the snippet:

```
document.addEventListener("DOMContentLoaded", function(event) {
  blockstack.redirectToSignIn(redirectURI, manifestURI)
})
```

